### PR TITLE
Created KafkaConfigHelper to configure Kafka consumer and producers

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/KafkaConsumerProducerHandler.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/KafkaConsumerProducerHandler.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.document.generator.consumer.kafka;
+
+import uk.gov.companieshouse.kafka.consumer.CHKafkaConsumerGroup;
+import uk.gov.companieshouse.kafka.producer.CHKafkaProducer;
+
+import java.util.List;
+
+public interface KafkaConsumerProducerHandler {
+    /**
+     * get the consumerGroup
+     *
+     * @param consumerTopics
+     * @param groupName
+     * @return
+     */
+    CHKafkaConsumerGroup getConsumerGroup(List<String> consumerTopics, String groupName);
+
+    /**
+     * Get kafka producer
+     *
+     * @return
+     */
+    CHKafkaProducer getProducer();
+}

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/KafkaBrokerConfigHelper.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/KafkaBrokerConfigHelper.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper;
+
+
+import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+
+public interface KafkaBrokerConfigHelper {
+
+    /**
+     * Assign broker address to the ConsumerConfigHelper
+     *
+     * @param consumerConfig
+     */
+    void configureConsumerBrokerAddress(ConsumerConfig consumerConfig);
+
+    /**
+     * Assign broker address to the ProducerConfigHelper
+     *
+     * @param producerConfig
+     */
+    void configureProducerBrokerAddress(ProducerConfig producerConfig);
+}

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/KafkaConfigHelper.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/KafkaConfigHelper.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper;
+
+import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+
+import java.util.List;
+
+public interface KafkaConfigHelper {
+
+    /**
+     * Generate the config for the  kafka consumer
+     *
+     * @param consumerTopics
+     * @param groupName
+     * @return consumerConfig
+     */
+    ConsumerConfig configureKafkaConsumer(List<String> consumerTopics, String groupName);
+
+    /**
+     * Generate the config for the kafka producer
+     *
+     * @return producerConfig
+     */
+    ProducerConfig configureKafkaProducer();
+}

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/impl/KafkaBrokerConfigHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/impl/KafkaBrokerConfigHelperImpl.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper.impl;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper.KafkaBrokerConfigHelper;
+import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
+import uk.gov.companieshouse.kafka.consumer.ConsumerConfigHelper;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+import uk.gov.companieshouse.kafka.producer.ProducerConfigHelper;
+
+@Service
+public class KafkaBrokerConfigHelperImpl implements KafkaBrokerConfigHelper {
+
+    /**
+     * Assign broker address to the ConsumerConfigHelper
+     *
+     * @param consumerConfig
+     */
+    @Override
+    public void configureConsumerBrokerAddress (ConsumerConfig consumerConfig) {
+        ConsumerConfigHelper.assignBrokerAddresses(consumerConfig);
+    }
+
+    /**
+     * Assign broker address to the ProducerConfigHelper
+     *
+     * @param producerConfig
+     */
+    @Override
+    public void configureProducerBrokerAddress (ProducerConfig producerConfig) {
+        ProducerConfigHelper.assignBrokerAddresses(producerConfig);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/impl/KafkaConfigHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/impl/KafkaConfigHelperImpl.java
@@ -1,0 +1,59 @@
+package uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper.KafkaBrokerConfigHelper;
+import uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper.KafkaConfigHelper;
+import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
+import uk.gov.companieshouse.kafka.producer.Acks;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+
+import java.util.List;
+
+@Service
+public class KafkaConfigHelperImpl implements KafkaConfigHelper {
+
+    @Autowired
+    private KafkaBrokerConfigHelper kafkaBrokerConfigHelper;
+
+    /**
+     * Configure the kafka consumer
+     *
+     * @param consumerTopics
+     * @param groupName
+     * @return consumerConfig
+     */
+    @Override
+    public ConsumerConfig configureKafkaConsumer(List<String> consumerTopics, String groupName) {
+
+        ConsumerConfig consumerConfig = new ConsumerConfig();
+
+        consumerConfig.setTopics(consumerTopics);
+        consumerConfig.setGroupName(groupName);
+        consumerConfig.setResetOffset(false);
+
+        kafkaBrokerConfigHelper.configureConsumerBrokerAddress(consumerConfig);
+
+        return consumerConfig;
+    }
+
+    /**
+     * Configure the kafka producer
+     *
+     * @return producerConfig
+     */
+    @Override
+    public ProducerConfig configureKafkaProducer() {
+
+        ProducerConfig producerConfig = new ProducerConfig();
+
+        producerConfig.setRoundRobinPartitioner(true);
+        producerConfig.setAcks(Acks.WAIT_FOR_ALL);
+        producerConfig.setRetries(10);
+
+        kafkaBrokerConfigHelper.configureProducerBrokerAddress(producerConfig);
+
+        return producerConfig;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/impl/KafkaConsumerProducerHandlerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/impl/KafkaConsumerProducerHandlerImpl.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.document.generator.consumer.kafka.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.document.generator.consumer.kafka.KafkaConsumerProducerHandler;
+import uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper.KafkaConfigHelper;
+import uk.gov.companieshouse.kafka.consumer.CHKafkaConsumerGroup;
+import uk.gov.companieshouse.kafka.producer.CHKafkaProducer;
+
+import java.util.List;
+
+@Component
+public class KafkaConsumerProducerHandlerImpl implements KafkaConsumerProducerHandler {
+
+    @Autowired
+    private KafkaConfigHelper kafkaConfigHelper;
+
+    /**
+     * get the  kafka consumer group
+     *
+     * @param consumerTopics
+     * @param groupName
+     * @return
+     */
+    @Override
+    public CHKafkaConsumerGroup getConsumerGroup(List<String> consumerTopics, String groupName) {
+        return new CHKafkaConsumerGroup(kafkaConfigHelper
+                .configureKafkaConsumer(consumerTopics, groupName));
+    }
+
+    /**
+     * Get kafka producer
+     *
+     * @return
+     */
+    @Override
+    public CHKafkaProducer getProducer() {
+        return new CHKafkaProducer(kafkaConfigHelper.configureKafkaProducer());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/KafkaConfigHelperImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/kafka/configurationhelper/KafkaConfigHelperImplTest.java
@@ -1,0 +1,60 @@
+package uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper;
+
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.document.generator.consumer.kafka.configurationhelper.impl.KafkaConfigHelperImpl;
+import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
+import uk.gov.companieshouse.kafka.producer.ProducerConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class KafkaConfigHelperImplTest {
+
+    @Mock
+    private KafkaBrokerConfigHelper kafkaBrokerConfigHelper;
+
+    @InjectMocks
+    private KafkaConfigHelperImpl kafkaConfigHelperImpl;
+
+    private static final String GROUP_NAME = "test-group";
+
+    private static final String TOPIC = "test-topic";
+
+
+    @Test
+    @DisplayName("Get the consumer configs successfully")
+    public void getConsumerConfig() {
+
+        MockitoAnnotations.initMocks(this);
+        List<String> consumerTopics = new ArrayList<>();
+        consumerTopics.add(TOPIC);
+
+        doNothing().when(kafkaBrokerConfigHelper).configureConsumerBrokerAddress(any(ConsumerConfig.class));
+        ConsumerConfig consumerConfig = kafkaConfigHelperImpl.configureKafkaConsumer(consumerTopics, GROUP_NAME);
+        assertNotNull(consumerConfig);
+    }
+
+    @Test
+    @DisplayName("Get the producer configs successfully")
+    public void getProducerConfig() {
+
+        MockitoAnnotations.initMocks(this);
+        doNothing().when(kafkaBrokerConfigHelper).configureProducerBrokerAddress(any(ProducerConfig.class));
+        ProducerConfig producerConfig = kafkaConfigHelperImpl.configureKafkaProducer();
+        assertNotNull(producerConfig);
+    }
+}


### PR DESCRIPTION
Added kafkaConfig helper to create the consumer or producer configs
Added kafkaBrokerConfigHelper to obtain the broker address
Added KafkaConsumerProducerHandler to create either a consumergroup or a producer

JUnit test added for kafkaConfigHelperImpl

Resolves SFA 662