### PR TITLE
 Create DocumentGeneratorConsumer class to poll Kafka for messages

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -28,6 +28,7 @@ public class DocumentGeneratorConsumer {
 
     private AvroDeserializer<DeserialisedKafkaMessage> avroDeserializer;
 
+    @Autowired
     public DocumentGeneratorConsumer(KafkaConsumerProducerHandler kafkaConsumerProducerHandler,
                                      EnvironmentReader environmentReader) {
 

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -57,10 +57,9 @@ public class DocumentGeneratorConsumer {
                 deserialisedKafkaMessage = avroDeserializer.deserialize(message, DeserialisedKafkaMessage.getClassSchema());
                 messageService.createDocumentGenerationStarted(deserialisedKafkaMessage);
             } catch (Exception e) {
+                LOG.error(e);
                 messageService.createDocumentGenerationFailed(deserialisedKafkaMessage, null);
                 consumerGroup.commit();
-                LOG.error(e);
-                throw new MessageCreationException(e.getMessage(), e.getCause());
             }
         }
     }

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -49,13 +49,15 @@ public class DocumentGeneratorConsumer {
     }
 
     public void pollAndGenerateDocument() throws MessageCreationException {
-
-        for(Message message : consumerGroup.consume()) {
+        for (Message message : consumerGroup.consume()) {
             DeserialisedKafkaMessage deserialisedKafkaMessage = null;
 
             try {
                 deserialisedKafkaMessage = avroDeserializer.deserialize(message, DeserialisedKafkaMessage.getClassSchema());
+
                 messageService.createDocumentGenerationStarted(deserialisedKafkaMessage);
+
+                consumerGroup.commit();
             } catch (Exception e) {
                 LOG.error(e);
                 messageService.createDocumentGenerationFailed(deserialisedKafkaMessage, null);

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -41,12 +41,12 @@ public class DocumentGeneratorConsumer {
             DeserialisedKafkaMessage deserialisedKafkaMessage = null;
 
             try {
-                deserialisedKafkaMessage = avroDeserializer.deserialize(message, deserialisedKafkaMessage.getSchema());
+                deserialisedKafkaMessage = avroDeserializer.deserialize(message, DeserialisedKafkaMessage.getClassSchema());
                 messageService.createDocumentGenerationStarted(deserialisedKafkaMessage);
             } catch (Exception e) {
-                LOG.error(e);
                 messageService.createDocumentGenerationFailed(deserialisedKafkaMessage, null);
                 consumerGroup.commit();
+                LOG.error(e);
                 throw new MessageCreationException(e.getMessage(), e.getCause());
             }
         }

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.document.generator.consumer.document;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.companieshouse.document.generator.consumer.avro.AvroDeserializer;
+import uk.gov.companieshouse.document.generator.consumer.document.models.avro.DeserialisedKafkaMessage;
+import uk.gov.companieshouse.document.generator.consumer.document.service.MessageService;
+import uk.gov.companieshouse.document.generator.consumer.exception.MessageCreationException;
+import uk.gov.companieshouse.document.generator.consumer.kafka.KafkaConsumerProducerHandler;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.kafka.consumer.CHKafkaConsumerGroup;
+import uk.gov.companieshouse.kafka.message.Message;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.Arrays;
+
+public class DocumentGeneratorConsumer {
+
+    private static final Logger LOG = LoggerFactory.getLogger("document-generator-consumer");
+
+    private static final String CONSUMER_TOPIC_VAR = "CONSUMER_TOPIC";
+    private static final String GROUP_NAME_VAR = "GROUP_NAME";
+
+    @Autowired
+    private MessageService messageService;
+
+    private CHKafkaConsumerGroup consumerGroup;
+
+    private AvroDeserializer<DeserialisedKafkaMessage> avroDeserializer;
+
+    public DocumentGeneratorConsumer(KafkaConsumerProducerHandler kafkaConsumerProducerHandler,
+                                     EnvironmentReader environmentReader) {
+
+        consumerGroup = kafkaConsumerProducerHandler.getConsumerGroup(Arrays.asList(
+                environmentReader.getMandatoryString(CONSUMER_TOPIC_VAR)),
+                environmentReader.getMandatoryString(GROUP_NAME_VAR));
+    }
+
+    private void pollAndGenerateDocument() throws MessageCreationException {
+        for(Message message : consumerGroup.consume()) {
+            DeserialisedKafkaMessage deserialisedKafkaMessage = null;
+
+            try {
+                deserialisedKafkaMessage = avroDeserializer.deserialize(message, deserialisedKafkaMessage.getSchema());
+                messageService.createDocumentGenerationStarted(deserialisedKafkaMessage);
+            } catch (Exception e) {
+                LOG.error(e);
+                messageService.createDocumentGenerationFailed(deserialisedKafkaMessage, null);
+                consumerGroup.commit();
+                throw new MessageCreationException(e.getMessage(), e.getCause());
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -26,18 +26,30 @@ public class DocumentGeneratorConsumer {
 
     private CHKafkaConsumerGroup consumerGroup;
 
+    private KafkaConsumerProducerHandler kafkaConsumerProducerHandler;
+
+    private EnvironmentReader environmentReader;
+
     private AvroDeserializer<DeserialisedKafkaMessage> avroDeserializer;
 
     @Autowired
     public DocumentGeneratorConsumer(KafkaConsumerProducerHandler kafkaConsumerProducerHandler,
-                                     EnvironmentReader environmentReader) {
+                                     EnvironmentReader environmentReader,
+                                     MessageService messageService,
+                                     AvroDeserializer<DeserialisedKafkaMessage> avroDeserializer) {
+
+        this.kafkaConsumerProducerHandler = kafkaConsumerProducerHandler;
+        this.environmentReader = environmentReader;
+        this.messageService = messageService;
+        this.avroDeserializer = avroDeserializer;
 
         consumerGroup = kafkaConsumerProducerHandler.getConsumerGroup(Arrays.asList(
                 environmentReader.getMandatoryString(CONSUMER_TOPIC_VAR)),
                 environmentReader.getMandatoryString(GROUP_NAME_VAR));
     }
 
-    private void pollAndGenerateDocument() throws MessageCreationException {
+    public void pollAndGenerateDocument() throws MessageCreationException {
+
         for(Message message : consumerGroup.consume()) {
             DeserialisedKafkaMessage deserialisedKafkaMessage = null;
 

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
@@ -53,8 +53,9 @@ public class DocumentGeneratorConsumerTests {
     @Mock
     private AvroDeserializer<DeserialisedKafkaMessage> mockAvroDeserializer;
 
-    List<Message> messages;
-    Message message;
+    private List<Message> messages;
+
+    private Message message;
 
     @BeforeEach
     void init () {

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
@@ -55,7 +55,7 @@ public class DocumentGeneratorConsumerTests {
     Message message;
 
     @BeforeEach
-    void init () throws Exception {
+    void init () {
         when(mockEnvironmentReader.getMandatoryString(any(String.class))).thenReturn("string");
         when(mockKafkaConsumerProducerHandler.getConsumerGroup(anyList(), any(String.class))).thenReturn(mockConsumerGroup);
         when(mockConsumerGroup.consume()).thenReturn(createTestMessageList());
@@ -65,8 +65,8 @@ public class DocumentGeneratorConsumerTests {
     }
 
     @Test
-    @DisplayName("Test polling of Kafka messages to request document generation")
-    void pollAndGenerateDocumentTest() throws Exception {
+    @DisplayName("Test message for create document generation started ")
+    void documentGenerationStartedMessageCreatedTest() throws Exception {
         when(mockAvroDeserializer.deserialize(any(Message.class), any(Schema.class))).thenReturn(mockDeserialisedKafkaMessage);
         documentGeneratorConsumer.pollAndGenerateDocument();
 

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.kafka.consumer.CHKafkaConsumerGroup;
 import uk.gov.companieshouse.kafka.message.Message;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,11 +68,20 @@ public class DocumentGeneratorConsumerTests {
 
     @Test
     @DisplayName("Test message for create document generation started ")
-    void documentGenerationStartedMessageCreatedTest() throws Exception {
+    void pollAndGenerateStartedMessageCreatedTest() throws Exception {
         when(mockAvroDeserializer.deserialize(any(Message.class), any(Schema.class))).thenReturn(mockDeserialisedKafkaMessage);
         documentGeneratorConsumer.pollAndGenerateDocument();
 
         assertEquals(any(Message.class), mockMessageService.createDocumentGenerationStarted(mockDeserialisedKafkaMessage));
+    }
+
+    @Test
+    @DisplayName("Test message for create document generation failed")
+    void pollAndGenerateFailedMessageVerifiedTest() throws Exception {
+        when(mockAvroDeserializer.deserialize(any(Message.class), any(Schema.class))).thenThrow(new IOException());
+        documentGeneratorConsumer.pollAndGenerateDocument();
+
+        verify(mockMessageService).createDocumentGenerationFailed(null, null);
     }
 
     private List< Message > createTestMessageList() {

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
@@ -1,11 +1,30 @@
 package uk.gov.companieshouse.document.generator.consumer.document;
 
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.document.generator.consumer.avro.AvroDeserializer;
+import uk.gov.companieshouse.document.generator.consumer.document.models.avro.DeserialisedKafkaMessage;
+import uk.gov.companieshouse.document.generator.consumer.document.service.MessageService;
+import uk.gov.companieshouse.document.generator.consumer.kafka.KafkaConsumerProducerHandler;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.kafka.consumer.CHKafkaConsumerGroup;
+import uk.gov.companieshouse.kafka.message.Message;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -14,9 +33,57 @@ public class DocumentGeneratorConsumerTests {
     @InjectMocks
     private DocumentGeneratorConsumer documentGeneratorConsumer;
 
+    @Mock
+    private CHKafkaConsumerGroup mockConsumerGroup;
+
+    @Mock
+    private KafkaConsumerProducerHandler mockKafkaConsumerProducerHandler;
+
+    @Mock
+    private EnvironmentReader mockEnvironmentReader;
+
+    @Mock
+    private MessageService mockMessageService;
+
+    @Mock
+    private DeserialisedKafkaMessage mockDeserialisedKafkaMessage;
+
+    @Mock
+    private AvroDeserializer<DeserialisedKafkaMessage> mockAvroDeserializer;
+
+    List<Message> messages;
+    Message message;
+
+    @BeforeEach
+    void init () throws Exception {
+        when(mockEnvironmentReader.getMandatoryString(any(String.class))).thenReturn("string");
+        when(mockKafkaConsumerProducerHandler.getConsumerGroup(anyList(), any(String.class))).thenReturn(mockConsumerGroup);
+        when(mockConsumerGroup.consume()).thenReturn(createTestMessageList());
+
+        documentGeneratorConsumer = new DocumentGeneratorConsumer(mockKafkaConsumerProducerHandler,
+                mockEnvironmentReader, mockMessageService, mockAvroDeserializer);
+    }
+
     @Test
     @DisplayName("Test polling of Kafka messages to request document generation")
-    void pollAndGenerateDocumentTest() {
+    void pollAndGenerateDocumentTest() throws Exception {
+        when(mockAvroDeserializer.deserialize(any(Message.class), any(Schema.class))).thenReturn(mockDeserialisedKafkaMessage);
+        documentGeneratorConsumer.pollAndGenerateDocument();
 
+        assertEquals(any(Message.class), mockMessageService.createDocumentGenerationStarted(mockDeserialisedKafkaMessage));
+    }
+
+    private List< Message > createTestMessageList() {
+        messages = new ArrayList< >();
+        message = new Message();
+        message.setKey("test key");
+        message.setOffset(100L);
+        message.setPartition(123);
+        message.setTimestamp(new Date().getTime());
+        message.setTopic("document-generation-started");
+        message.setValue("value 1".getBytes());
+        messages.add(message);
+
+        return messages;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.document.generator.consumer.document;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DocumentGeneratorConsumerTests {
+
+    @InjectMocks
+    private DocumentGeneratorConsumer documentGeneratorConsumer;
+
+    @Test
+    @DisplayName("Test polling of Kafka messages to request document generation")
+    void pollAndGenerateDocumentTest() {
+
+    }
+}


### PR DESCRIPTION
Add initial DocumentGeneratorConsumer class and tests which will loop and consume messages from Kafka to be deserialised using the Avro deserialiser.

Then send a message to Kafka producer to tell if process has started or failed when deserialising the message.

**Note** The method "pollAndGenerateDocument is named as such as the next step is to plug in the generate document code.

**Resolves**: SFA-716