### PR TITLE
Fix broken DocumentGeneratorConsumerTest

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -41,7 +41,6 @@ public class DocumentGeneratorConsumer implements Runnable {
 
     private AvroDeserializer<DeserialisedKafkaMessage> avroDeserializer;
 
-    @Autowired
     private DocumentGeneratorConsumerProperties configuration;
 
     @Autowired
@@ -50,7 +49,8 @@ public class DocumentGeneratorConsumer implements Runnable {
                                      MessageService messageService,
                                      AvroDeserializer<DeserialisedKafkaMessage> avroDeserializer,
                                      RestTemplate restTemplate,
-                                     CHKafkaProducer producer) {
+                                     CHKafkaProducer producer,
+                                     DocumentGeneratorConsumerProperties configuration) {
 
         this.kafkaConsumerProducerHandler = kafkaConsumerProducerHandler;
         this.environmentReader = environmentReader;
@@ -58,6 +58,7 @@ public class DocumentGeneratorConsumer implements Runnable {
         this.avroDeserializer = avroDeserializer;
         this.restTemplate = restTemplate;
         this.producer = producer;
+        this.configuration = configuration;
 
         consumerGroup = kafkaConsumerProducerHandler.getConsumerGroup(Arrays.asList(
                 environmentReader.getMandatoryString(CONSUMER_TOPIC_VAR)),

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.document.generator.consumer.DocumentGeneratorConsumerProperties;
 import uk.gov.companieshouse.document.generator.consumer.avro.AvroDeserializer;
 import uk.gov.companieshouse.document.generator.consumer.document.models.GenerateDocumentRequest;
 import uk.gov.companieshouse.document.generator.consumer.document.models.GenerateDocumentResponse;
@@ -68,6 +69,9 @@ public class DocumentGeneratorConsumerTests {
     @Mock
     private RestTemplate mockRestTemplate;
 
+    @Mock
+    private DocumentGeneratorConsumerProperties mockProperties;
+
     private List<Message> messages;
 
     private Message message;
@@ -78,7 +82,8 @@ public class DocumentGeneratorConsumerTests {
         when(mockKafkaConsumerProducerHandler.getConsumerGroup(anyList(), any(String.class))).thenReturn(mockConsumerGroup);
 
         documentGeneratorConsumer = new DocumentGeneratorConsumer(mockKafkaConsumerProducerHandler,
-                mockEnvironmentReader, mockMessageService, mockAvroDeserializer, mockRestTemplate, mockCHKafkaProducer);
+                mockEnvironmentReader, mockMessageService, mockAvroDeserializer, mockRestTemplate,
+                mockCHKafkaProducer, mockProperties);
     }
 
     @Test


### PR DESCRIPTION
Fix for broken tests. Add DocumentGeneratorConsumerProperties to the constructor injection and add mockProperties to test.

**Resolves**: SFA-717