### PR TITLE
Corrections to Document Generator Consumer 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumer.java
@@ -49,7 +49,6 @@ public class DocumentGeneratorConsumer implements Runnable {
                                      MessageService messageService,
                                      AvroDeserializer<DeserialisedKafkaMessage> avroDeserializer,
                                      RestTemplate restTemplate,
-                                     CHKafkaProducer producer,
                                      DocumentGeneratorConsumerProperties configuration) {
 
         this.kafkaConsumerProducerHandler = kafkaConsumerProducerHandler;
@@ -57,12 +56,13 @@ public class DocumentGeneratorConsumer implements Runnable {
         this.messageService = messageService;
         this.avroDeserializer = avroDeserializer;
         this.restTemplate = restTemplate;
-        this.producer = producer;
         this.configuration = configuration;
 
         consumerGroup = kafkaConsumerProducerHandler.getConsumerGroup(Arrays.asList(
                 environmentReader.getMandatoryString(CONSUMER_TOPIC_VAR)),
                 environmentReader.getMandatoryString(GROUP_NAME_VAR));
+
+        producer = kafkaConsumerProducerHandler.getProducer();
     }
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
+++ b/src/test/java/uk/gov/companieshouse/document/generator/consumer/document/DocumentGeneratorConsumerTests.java
@@ -80,10 +80,11 @@ public class DocumentGeneratorConsumerTests {
     void init() {
         when(mockEnvironmentReader.getMandatoryString(any(String.class))).thenReturn("string");
         when(mockKafkaConsumerProducerHandler.getConsumerGroup(anyList(), any(String.class))).thenReturn(mockConsumerGroup);
+        when(mockKafkaConsumerProducerHandler.getProducer()).thenReturn(mockCHKafkaProducer);
 
         documentGeneratorConsumer = new DocumentGeneratorConsumer(mockKafkaConsumerProducerHandler,
                 mockEnvironmentReader, mockMessageService, mockAvroDeserializer, mockRestTemplate,
-                mockCHKafkaProducer, mockProperties);
+                mockProperties);
     }
 
     @Test


### PR DESCRIPTION
Corrected document-generator-consumer

- Updated document-generator-consumer to set the producer in the constructor using kafkaConsumerProducerHandler.getProducer();
- Corrected Junit test to reflect changes

Resolves SFA - 855