### PR TITLE
Document Generator Consumer Sonar bug fix

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/DocumentGeneratorConsumerApplication.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/DocumentGeneratorConsumerApplication.java
@@ -121,6 +121,7 @@ public class DocumentGeneratorConsumerApplication implements WebMvcConfigurer {
                 data.put("message", "InterruptionException");
 
                 LOGGER.error(e, data);
+                Thread.currentThread().interrupt();
             }
         }
         LOGGER.info("Finished closing Document Generator Consumer message processor");

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/processor/MessageProcessorRunner.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/processor/MessageProcessorRunner.java
@@ -36,6 +36,7 @@ public class MessageProcessorRunner implements Runnable {
             }
         } catch(InterruptedException e) {
             LOG.error(e);
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/processor/impl/MessageProcessorImpl.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/processor/impl/MessageProcessorImpl.java
@@ -58,6 +58,7 @@ public class MessageProcessorImpl implements MessageProcessor {
                 Thread.sleep(1000);
             } catch (InterruptedException ie) {
                 LOG.debug("Interrupt exception - exiting message processing");
+                Thread.currentThread().interrupt();
                 return;
             }
         } else {


### PR DESCRIPTION
Sonar advised that interruptionExceptions should not be ignored, and logging is classed as ignoring. 

- Applied Thread.currentThread().interrupt() to all areas in document-generator-consumer where an interruptException is thrown to re interrupt the thread as advised in the sonar details.