### PR TITLE
Changes to request a public location to Doc Generator

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/models/GenerateDocumentRequest.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/models/GenerateDocumentRequest.java
@@ -14,6 +14,9 @@ public class GenerateDocumentRequest {
     @JsonProperty("document_type")
     private String documentType;
 
+    @JsonProperty("is_public_location_required")
+    private boolean isPublicLocationRequired;
+
     public String getResourceUri() {
         return resourceUri;
     }
@@ -36,6 +39,14 @@ public class GenerateDocumentRequest {
 
     public void setDocumentType(String documentType) {
         this.documentType = documentType;
+    }
+
+    public boolean isPublicLocationRequired() {
+        return isPublicLocationRequired;
+    }
+
+    public void setPublicLocationRequired(boolean publicLocationRequired) {
+        isPublicLocationRequired = publicLocationRequired;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/service/impl/GenerateDocumentImpl.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/document/service/impl/GenerateDocumentImpl.java
@@ -80,6 +80,8 @@ public class GenerateDocumentImpl implements GenerateDocument {
         request.setResourceUri(deserialisedKafkaMessage.getResource());
         request.setMimeType(deserialisedKafkaMessage.getContentType());
         request.setDocumentType(deserialisedKafkaMessage.getDocumentType());
+        request.setPublicLocationRequired(true);
+
         return request;
     }
 


### PR DESCRIPTION
Code changes to request a public location when calling the **Doc Generator.** 

This change is needed as **Document Generator** is changing to default the ixbrl location to private (https://github.com/companieshouse/document-generator/pull/85). Therefore, **Document Generator Consumer,** which needs a ixbrl in a public location, will fail as the Doc. Generator will return a private one. 

Resolve: SFA-1020