### PR TITLE
Update environment variable check on startup

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/DocumentGeneratorConsumerApplication.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/DocumentGeneratorConsumerApplication.java
@@ -89,7 +89,7 @@ public class DocumentGeneratorConsumerApplication implements WebMvcConfigurer {
                 String paramValue = reader.getMandatoryString(param);
                 LOGGER.info("Environment variable " + param + " has value " + paramValue);
             } catch (EnvironmentVariableException e) {
-                LOGGER.error("Environment variable " + param + " is not set");
+                LOGGER.error("Environment variable " + param + " is not set", e);
                 environmentParamMissing.set(true);
             }
         });


### PR DESCRIPTION
Updated the environmental variable check on start-up as previously it would crash out on the first missing variable. Now it continues to check all variable noted, marks the missing and then once complete throws a RunTimeError if there is a missing variable.

Resolves SFA-715