### PR TITLE
Setting EnableIdempotence as false for kafka producer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/impl/KafkaProducerServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/document/generator/consumer/kafka/impl/KafkaProducerServiceImpl.java
@@ -33,6 +33,7 @@ public class KafkaProducerServiceImpl implements KafkaProducerService {
 
         ProducerConfigHelper.assignBrokerAddresses(producerConfig);
         producer = new CHKafkaProducer(producerConfig);
+        config = new ProducerConfig();
         config.setEnableIdempotence(false);
     }
 


### PR DESCRIPTION
Setting EnableIdempotence as false for kafka producer