### PR TITLE
Increase cidev memory and cpu to prevent service failures

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -8,8 +8,10 @@ log_level = "trace"
 # Scheduled scaling of tasks
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
-service_autoscale_scale_out_cooldown = 600
 
+required_cpus = 512
+required_memory = 1024
+service_autoscale_scale_out_cooldown = 600
 
 # Enable Parallel Old Kafka Service
 create_old_kafka_service = false


### PR DESCRIPTION
Update memory and cpu for cidev instance of document generator consumer due to service reaching maximum memory capicity causing company snapshot to fail.